### PR TITLE
Embed license in binary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module main
 
-go 1.13
+go 1.16
 
 require github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -46,6 +47,9 @@ var allowZipDir *bool
 
 var useAuth bool
 
+//go:embed LICENSE
+var license string
+
 func getConfigFilePath() (string, error) {
 	//Get Config filename
 	//remove any extension from executable, then append CONFIG_APPEND const ("Config.json")
@@ -62,6 +66,10 @@ func getConfigFilePath() (string, error) {
 
 func printHelp() {
 	flag.PrintDefaults()
+}
+
+func printLicense() {
+	fmt.Printf("%s", license)
 }
 
 type config struct {
@@ -466,6 +474,7 @@ func init() {
 
 	var printConfig = flag.Bool("printConfig", false, "Prints default Config file")
 	var help = flag.Bool("h", false, "Prints help")
+	var license = flag.Bool("license", false, "Prints license")
 
 	flag.Parse()
 
@@ -483,6 +492,11 @@ func init() {
 
 	if *help {
 		printHelp()
+		os.Exit(0)
+	}
+
+	if *license {
+		printLicense()
 		os.Exit(0)
 	}
 

--- a/mc.yaml
+++ b/mc.yaml
@@ -2,8 +2,16 @@
 base: ubuntu:20.04
 install:
  - git
- - golang
  - make
+
+ - curl
+ - gzip
+ - tar
 publish:
  - 9000:9000
 ---
+#!/bin/bash
+
+curl --location 'https://golang.org/dl/go1.16beta1.linux-amd64.tar.gz' | sudo tar xz --directory='/opt'
+sudo ln -s '/opt/go/bin/go' '/usr/local/bin/go'
+


### PR DESCRIPTION
Using Go 1.16's embed feature, it's really easy to embed the licenses' text into the generated binaries. This patch should not be merged until Go 1.16 is officially released.

Fixes issue #1